### PR TITLE
Breakfix Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [1.0.1] - 2025-04-01
+
+### Changed
+
+- Query params are case-sensitive, discovered query params were not working properly in Get-AxoniusQueries and Get-AxoniusAssetsByID. Added ToLower() functions for these params.
+
+
 ## [1.0.0] - 2025-03-24
 
 ### Added

--- a/src/UofIAxonius/UofIAxonius.psd1
+++ b/src/UofIAxonius/UofIAxonius.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofIAxonius.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.0.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/UofIAxonius/UofIAxonius.psd1
+++ b/src/UofIAxonius/UofIAxonius.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofIAxonius.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.2'
+ModuleVersion = '1.0.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/UofIAxonius/functions/public/Get-AxoniusAssetByID.ps1
+++ b/src/UofIAxonius/functions/public/Get-AxoniusAssetByID.ps1
@@ -42,7 +42,7 @@ function Get-AxoniusAssetByID{
         $PSCmdlet.MyInvocation.BoundParameters.GetEnumerator() | ForEach-Object {
             if($_.Key -notin $ExcludedKeys){
                 $alias = $MyInvocation.MyCommand.Parameters[$_.Key].Aliases[0]
-                $paramName = $alias ?? $_.Key
+                $paramName = $alias ?? $_.Key.ToLower()
                 $QueryObjects += "$($paramName)=$($_.Value)"
             }
         }

--- a/src/UofIAxonius/functions/public/Get-AxoniusQueries.ps1
+++ b/src/UofIAxonius/functions/public/Get-AxoniusQueries.ps1
@@ -48,7 +48,7 @@ function Get-AxoniusQueries{
 
         $PSCmdlet.MyInvocation.BoundParameters.GetEnumerator() | ForEach-Object {
             $alias = $MyInvocation.MyCommand.Parameters[$_.Key].Aliases[0]
-            $paramName = $alias ?? $_.Key
+            $paramName = $alias ?? $_.Key.ToLower()
 
             # Handle array parameters by adding multiple entries
             if ($_.Value -is [array]) {


### PR DESCRIPTION
## [1.0.1] - 2025-04-01

### Changed

- Query params are case-sensitive, discovered query params were not working properly in Get-AxoniusQueries and Get-AxoniusAssetsByID. Added ToLower() functions for these params.
